### PR TITLE
It seems we can not i18n -default-  field value anymore (earlier evaluation ?)

### DIFF
--- a/edx_gea/gea.py
+++ b/edx_gea/gea.py
@@ -31,14 +31,16 @@ class GradeExternalActivityXBlock(XBlock, StudioEditableXBlockMixin):
     icon_class = 'problem'
 
     display_name = String(
-        default=ugettext_lazy('External Activity Grader'), scope=Scope.settings,
-        help="This name appears in the horizontal navigation at the top of "
+        display_name=ugettext_lazy(u"External Activity Grader"), 
+        default=u"External Activity Grader", 
+        scope=Scope.settings,
+        help=u"This name appears in the horizontal navigation at the top of "
              "the page."
     )
 
     points = Integer(
-        display_name=ugettext_lazy("Maximum grade"),
-        help=(ugettext_lazy("Maximum grade of the external activity.")),
+        display_name=ugettext_lazy(u"Maximum grade"),
+        help=(ugettext_lazy(u"Maximum grade of the external activity.")),
         default=10,
         scope=Scope.settings
     )


### PR DESCRIPTION
Lors de l'initialisation de Django, on obtient le message suivant: 

`
"The translation infrastructure cannot be initialized before the "
django.core.exceptions.AppRegistryNotReady: The translation infrastructure
cannot be initialized before the apps registry is ready. Check that you don
't make non-lazy gettext calls at import time.
`
